### PR TITLE
Ajout de la configuration des paramètres de sécurité

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Installation
 ```
 
 - Activate it from the admin → Settings → Plugins page
+- If necessary, allow the upload of XML files in the [Security Settings](https://omeka.org/classic/docs/Admin/Settings/Security_Settings/): Add `xml` to the `Allowed File Extensions` list and `application/xml` to the `Allowed File Types` list.
 - Click the Configure link to process or not existing PDF files.
 
 


### PR DESCRIPTION
Bonjour, Suite à l'installation du plugin sous Omeka 2.6, j'ai dû autoriser manuellement le transfert de fichiers XML dans les paramètres de sécurité. Je propose donc de rajouter cette opération à la procédure d'installation. Bien cordialement,